### PR TITLE
feat: バイク比較機能追加 (#18)

### DIFF
--- a/web/src/components/CatalogPage.tsx
+++ b/web/src/components/CatalogPage.tsx
@@ -45,6 +45,8 @@ export default function CatalogPage() {
   });
   const [collapsedCats, setCollapsedCats] = useState<Set<string>>(new Set());
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [compareIds, setCompareIds] = useState<number[]>([]);
+  const [showCompare, setShowCompare] = useState(false);
 
   useEffect(() => {
     fetchJson<Tag[]>("/motorcycles/tags/all").then(setTags);
@@ -114,6 +116,14 @@ export default function CatalogPage() {
       [key]: { ...prev[key], [side]: value },
     }));
   };
+
+  const toggleCompare = (id: number) => {
+    setCompareIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : prev.length < 3 ? [...prev, id] : prev
+    );
+  };
+
+  const compareBikes = compareIds.map((id) => bikes.find((b) => b.id === id)).filter(Boolean) as Motorcycle[];
 
   const toggleCollapse = (cat: string) => {
     setCollapsedCats((prev) => {
@@ -333,6 +343,13 @@ export default function CatalogPage() {
                       <span key={t.id} className="card-tag">{t.name}</span>
                     ))}
                   </div>
+                  <button
+                    className={`compare-btn ${compareIds.includes(bike.id) ? "compare-btn-active" : ""}`}
+                    onClick={() => toggleCompare(bike.id)}
+                    disabled={!compareIds.includes(bike.id) && compareIds.length >= 3}
+                  >
+                    {compareIds.includes(bike.id) ? "比較から外す" : "比較に追加"}
+                  </button>
                 </div>
               </div>
             ))}
@@ -342,6 +359,73 @@ export default function CatalogPage() {
           </div>
         </main>
       </div>
+
+      {compareIds.length > 0 && !showCompare && (
+        <div className="compare-tray">
+          <div className="compare-tray-content">
+            <span className="compare-tray-label">比較: {compareIds.length}台選択中</span>
+            <div className="compare-tray-bikes">
+              {compareBikes.map((b) => (
+                <span key={b.id} className="compare-tray-chip">
+                  {b.name}
+                  <button className="compare-chip-remove" onClick={() => toggleCompare(b.id)}>&times;</button>
+                </span>
+              ))}
+            </div>
+            <button
+              className="compare-tray-open"
+              onClick={() => setShowCompare(true)}
+              disabled={compareIds.length < 2}
+            >
+              比較する
+            </button>
+          </div>
+        </div>
+      )}
+
+      {showCompare && (
+        <div className="compare-overlay" onClick={() => setShowCompare(false)}>
+          <div className="compare-modal" onClick={(e) => e.stopPropagation()}>
+            <div className="compare-modal-header">
+              <h2>スペック比較</h2>
+              <button className="compare-modal-close" onClick={() => setShowCompare(false)}>&times;</button>
+            </div>
+            <div className="compare-table-wrap">
+              <table className="compare-table">
+                <thead>
+                  <tr>
+                    <th></th>
+                    {compareBikes.map((b) => (
+                      <th key={b.id}>{b.name}</th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {([
+                    ["メーカー", (b: Motorcycle) => b.maker],
+                    ["排気量", (b: Motorcycle) => b.displacement ? `${b.displacement}cc` : "-"],
+                    ["年式", (b: Motorcycle) => b.year ? `${b.year}年` : "-"],
+                    ["最高出力", (b: Motorcycle) => b.max_power != null ? `${b.max_power} PS` : "-"],
+                    ["最大トルク", (b: Motorcycle) => b.max_torque != null ? `${b.max_torque} N·m` : "-"],
+                    ["シート高", (b: Motorcycle) => b.seat_height != null ? `${b.seat_height} mm` : "-"],
+                  ] as [string, (b: Motorcycle) => string][]).map(([label, fn]) => {
+                    const vals = compareBikes.map(fn);
+                    const allSame = vals.every((v) => v === vals[0]);
+                    return (
+                      <tr key={label}>
+                        <td className="compare-label">{label}</td>
+                        {vals.map((v, i) => (
+                          <td key={i} className={!allSame ? "compare-diff" : ""}>{v}</td>
+                        ))}
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -583,6 +583,196 @@ body {
   padding: var(--spacingXXS) var(--spacingS);
 }
 
+/* Compare Button on Card */
+.compare-btn {
+  margin-top: var(--spacingS);
+  width: 100%;
+  padding: var(--spacingXS) var(--spacingM);
+  font-size: var(--fontSizeBase200);
+  font-family: var(--fontFamilyBase);
+  border: var(--strokeWidthThin) solid var(--colorNeutralStroke1);
+  border-radius: var(--borderRadiusMedium);
+  background: var(--colorNeutralBackground1);
+  color: var(--colorNeutralForeground2);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.compare-btn:hover:not(:disabled) {
+  background: var(--colorNeutralBackground3);
+}
+
+.compare-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.compare-btn-active {
+  background: #e8f4fd;
+  color: var(--colorBrandForeground1);
+  border-color: var(--colorBrandStroke1);
+}
+
+/* Compare Tray */
+.compare-tray {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--colorNeutralBackground1);
+  border-top: var(--strokeWidthThin) solid var(--colorNeutralStroke1);
+  box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.1);
+  z-index: 200;
+  padding: var(--spacingM) var(--spacingXXL);
+}
+
+.compare-tray-content {
+  display: flex;
+  align-items: center;
+  gap: var(--spacingM);
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.compare-tray-label {
+  font-size: var(--fontSizeBase300);
+  font-weight: var(--fontWeightSemibold);
+  color: var(--colorNeutralForeground1);
+  flex-shrink: 0;
+}
+
+.compare-tray-bikes {
+  display: flex;
+  gap: var(--spacingXS);
+  flex: 1;
+  overflow-x: auto;
+}
+
+.compare-tray-chip {
+  display: flex;
+  align-items: center;
+  gap: var(--spacingXS);
+  background: #e8f4fd;
+  color: var(--colorBrandForeground1);
+  padding: var(--spacingXS) var(--spacingS);
+  border-radius: var(--borderRadiusCircular);
+  font-size: var(--fontSizeBase200);
+  white-space: nowrap;
+}
+
+.compare-chip-remove {
+  background: none;
+  border: none;
+  color: var(--colorBrandForeground1);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 0;
+}
+
+.compare-tray-open {
+  padding: var(--spacingS) var(--spacingXL);
+  background: var(--colorBrandBackground);
+  color: #fff;
+  border: none;
+  border-radius: var(--borderRadiusMedium);
+  cursor: pointer;
+  font-size: var(--fontSizeBase300);
+  font-family: var(--fontFamilyBase);
+  font-weight: var(--fontWeightSemibold);
+  flex-shrink: 0;
+  transition: background 0.15s;
+}
+
+.compare-tray-open:hover:not(:disabled) {
+  background: var(--colorBrandBackgroundHover);
+}
+
+.compare-tray-open:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Compare Modal */
+.compare-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 300;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacingXXL);
+}
+
+.compare-modal {
+  background: var(--colorNeutralBackground1);
+  border-radius: var(--borderRadius2XLarge);
+  box-shadow: var(--shadow16);
+  max-width: 800px;
+  width: 100%;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.compare-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--spacingXL);
+  border-bottom: var(--strokeWidthThin) solid var(--colorNeutralStroke2);
+}
+
+.compare-modal-header h2 {
+  margin: 0;
+  font-size: var(--fontSizeBase500);
+  color: var(--colorNeutralForeground1);
+}
+
+.compare-modal-close {
+  background: none;
+  border: none;
+  font-size: 24px;
+  color: var(--colorNeutralForeground3);
+  cursor: pointer;
+  padding: var(--spacingXS);
+}
+
+.compare-table-wrap {
+  overflow: auto;
+  padding: var(--spacingXL);
+}
+
+.compare-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--fontSizeBase300);
+}
+
+.compare-table th,
+.compare-table td {
+  padding: var(--spacingS) var(--spacingM);
+  text-align: left;
+  border-bottom: var(--strokeWidthThin) solid var(--colorNeutralStroke3);
+}
+
+.compare-table th {
+  font-weight: var(--fontWeightSemibold);
+  color: var(--colorBrandForeground1);
+}
+
+.compare-label {
+  font-weight: var(--fontWeightSemibold);
+  color: var(--colorNeutralForeground3);
+  white-space: nowrap;
+}
+
+.compare-diff {
+  background: #fffde7;
+  font-weight: var(--fontWeightSemibold);
+}
+
 .no-results {
   color: var(--colorNeutralForeground4);
   grid-column: 1 / -1;


### PR DESCRIPTION
## Summary
- 最大3台のバイクを選択して比較できる機能を追加
- 比較トレイと比較モーダルUIを実装
- スペック差分のハイライト表示

## Test plan
- [ ] カードの比較ボタンで最大3台選択できること
- [ ] 比較モーダルでスペックが並列表示されること
- [ ] 差分がハイライトされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)