### PR TITLE
feat: 現行モデル/生産終了区分追加 (#23)

### DIFF
--- a/api/app/models.py
+++ b/api/app/models.py
@@ -31,4 +31,5 @@ class Motorcycle(Base):
     seat_height = Column(Integer)           # mm
     description = Column(Text)
     image_url = Column(String)
+    status = Column(String, default="current")  # "current" or "discontinued"
     tags = relationship("Tag", secondary=motorcycle_tag, backref="motorcycles")

--- a/api/app/routers/motorcycles.py
+++ b/api/app/routers/motorcycles.py
@@ -22,6 +22,7 @@ def list_motorcycles(
     torque_max: float | None = None,
     seat_height_min: int | None = None,
     seat_height_max: int | None = None,
+    status: str | None = None,
     db: Session = Depends(get_db),
 ):
     query = db.query(Motorcycle).options(joinedload(Motorcycle.tags))
@@ -60,6 +61,8 @@ def list_motorcycles(
         query = query.filter(Motorcycle.seat_height >= seat_height_min)
     if seat_height_max is not None:
         query = query.filter(Motorcycle.seat_height <= seat_height_max)
+    if status:
+        query = query.filter(Motorcycle.status == status)
     return query.all()
 
 

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -19,5 +19,6 @@ class MotorcycleOut(BaseModel):
     seat_height: int | None
     description: str | None
     image_url: str | None
+    status: str | None
     tags: list[TagOut]
     model_config = {"from_attributes": True}

--- a/api/app/seed.py
+++ b/api/app/seed.py
@@ -46,7 +46,7 @@ BIKES = [
     # HONDA (18車種)
     # ============================================================
     {
-        "name": "CB400 SUPER FOUR", "maker": "HONDA",
+        "name": "CB400 SUPER FOUR", "maker": "HONDA", "status": "discontinued",
         "displacement": 399, "year": 2022, "max_power": 56, "max_torque": 39, "seat_height": 755,
         "description": "ホンダの名車。教習車としても有名な直列4気筒ネイキッド。HYPER VTECによる可変バルブが特徴。",
         "tags": ["HONDA", "ネイキッド", "水冷", "倒立フォーク", "モノショック", "ダイヤモンドフレーム", "直列", "四気筒", "4バルブ", "フューエルインジェクション", "湿式クラッチ", "チェーン", "ABS", "セルスタート"],
@@ -148,7 +148,7 @@ BIKES = [
         "tags": ["HONDA", "アドベンチャー", "水冷", "倒立フォーク", "モノショック", "ダイヤモンドフレーム", "並列", "二気筒", "4バルブ", "フューエルインジェクション", "湿式クラッチ", "チェーン", "ABS", "セルスタート"],
     },
     {
-        "name": "Hawk 11", "maker": "HONDA",
+        "name": "Hawk 11", "maker": "HONDA", "status": "discontinued",
         "displacement": 1082, "year": 2022, "max_power": 102, "max_torque": 104, "seat_height": 820,
         "description": "FRPロケットカウルを纏うカフェレーサー。アフリカツインの並列2気筒を搭載した日本市場専用モデル。",
         "tags": ["HONDA", "ネオクラシック", "水冷", "倒立フォーク", "モノショック", "ダイヤモンドフレーム", "並列", "二気筒", "4バルブ", "フューエルインジェクション", "湿式クラッチ", "チェーン", "ABS", "セルスタート"],
@@ -169,13 +169,13 @@ BIKES = [
         "tags": ["YAMAHA", "ネイキッド", "水冷", "倒立フォーク", "モノショック", "ダイヤモンドフレーム", "直列", "三気筒", "4バルブ", "フューエルインジェクション", "湿式クラッチ", "チェーン", "ABS", "セルスタート"],
     },
     {
-        "name": "SR400", "maker": "YAMAHA",
+        "name": "SR400", "maker": "YAMAHA", "status": "discontinued",
         "displacement": 399, "year": 2021, "max_power": 24, "max_torque": 28, "seat_height": 790,
         "description": "ヤマハの空冷単気筒。キックスタート専用のクラシックバイク。43年間愛された名車。",
         "tags": ["YAMAHA", "ネオクラシック", "空冷", "テレスコピックフォーク", "ツインショック", "ダイヤモンドフレーム", "直列", "単気筒", "2バルブ", "フューエルインジェクション", "湿式クラッチ", "チェーン", "ABS無し", "キックスタート"],
     },
     {
-        "name": "YZF-R1", "maker": "YAMAHA",
+        "name": "YZF-R1", "maker": "YAMAHA", "status": "discontinued",
         "displacement": 997, "year": 2019, "max_power": 200, "max_torque": 113, "seat_height": 855,
         "description": "クロスプレーンエンジン搭載のフラッグシップSS。MotoGP M1の技術を受け継ぐ。",
         "tags": ["YAMAHA", "スーパースポーツ", "水冷", "倒立フォーク", "モノショック", "ツインスパーフレーム", "直列", "四気筒", "4バルブ", "フューエルインジェクション", "湿式クラッチ", "チェーン", "コーナリングABS", "セルスタート"],
@@ -229,7 +229,7 @@ BIKES = [
         "tags": ["YAMAHA", "アドベンチャー", "水冷", "倒立フォーク", "モノショック", "ダイヤモンドフレーム", "並列", "二気筒", "4バルブ", "フューエルインジェクション", "湿式クラッチ", "チェーン", "ABS", "セルスタート"],
     },
     {
-        "name": "BOLT", "maker": "YAMAHA",
+        "name": "BOLT", "maker": "YAMAHA", "status": "discontinued",
         "displacement": 941, "year": 2013, "max_power": 52, "max_torque": 80, "seat_height": 690,
         "description": "空冷Vツインのアメリカンクルーザー。低いシート高とボバースタイルのデザインが特徴。",
         "tags": ["YAMAHA", "クルーザー", "空冷", "テレスコピックフォーク", "ツインショック", "ダイヤモンドフレーム", "V型", "二気筒", "4バルブ", "フューエルインジェクション", "湿式クラッチ", "ベルトドライブ", "ABS", "セルスタート"],
@@ -262,7 +262,7 @@ BIKES = [
         "tags": ["SUZUKI", "アドベンチャー", "油冷", "倒立フォーク", "モノショック", "ダイヤモンドフレーム", "直列", "単気筒", "4バルブ", "フューエルインジェクション", "湿式クラッチ", "チェーン", "ABS", "セルスタート"],
     },
     {
-        "name": "GSX-R1000R", "maker": "SUZUKI",
+        "name": "GSX-R1000R", "maker": "SUZUKI", "status": "discontinued",
         "displacement": 998, "year": 2017, "max_power": 202, "max_torque": 110, "seat_height": 825,
         "description": "MotoGP技術を投入したフラッグシップSS。可変バルブタイミング（SR-VVT）を採用。",
         "tags": ["SUZUKI", "スーパースポーツ", "水冷", "倒立フォーク", "モノショック", "ツインスパーフレーム", "直列", "四気筒", "4バルブ", "フューエルインジェクション", "湿式クラッチ", "チェーン", "コーナリングABS", "セルスタート"],
@@ -292,7 +292,7 @@ BIKES = [
         "tags": ["SUZUKI", "スーパースポーツ", "水冷", "倒立フォーク", "モノショック", "ダイヤモンドフレーム", "並列", "二気筒", "4バルブ", "フューエルインジェクション", "湿式クラッチ", "チェーン", "ABS", "セルスタート"],
     },
     {
-        "name": "SV650", "maker": "SUZUKI",
+        "name": "SV650", "maker": "SUZUKI", "status": "discontinued",
         "displacement": 645, "year": 2016, "max_power": 72, "max_torque": 63, "seat_height": 785,
         "description": "90度Vツインのスタンダードネイキッド。軽量でバランスが良く、ライディングの基本を学べる名車。",
         "tags": ["SUZUKI", "ネイキッド", "水冷", "テレスコピックフォーク", "モノショック", "トレリスフレーム", "V型", "二気筒", "4バルブ", "フューエルインジェクション", "湿式クラッチ", "チェーン", "ABS", "セルスタート"],
@@ -316,7 +316,7 @@ BIKES = [
         "tags": ["SUZUKI", "モタード", "水冷", "倒立フォーク", "モノショック", "ダイヤモンドフレーム", "並列", "単気筒", "4バルブ", "フューエルインジェクション", "湿式クラッチ", "チェーン", "ABS", "セルスタート"],
     },
     {
-        "name": "GSX250R", "maker": "SUZUKI",
+        "name": "GSX250R", "maker": "SUZUKI", "status": "discontinued",
         "displacement": 248, "year": 2017, "max_power": 24, "max_torque": 22, "seat_height": 790,
         "description": "フルカウルの250ccツアラースポーツ。穏やかな出力特性で長距離ツーリングを快適にこなす。",
         "tags": ["SUZUKI", "スーパースポーツ", "水冷", "テレスコピックフォーク", "モノショック", "ダイヤモンドフレーム", "並列", "二気筒", "4バルブ", "フューエルインジェクション", "湿式クラッチ", "チェーン", "ABS", "セルスタート"],
@@ -385,13 +385,13 @@ BIKES = [
         "tags": ["KAWASAKI", "ネオクラシック", "水冷", "テレスコピックフォーク", "モノショック", "トレリスフレーム", "並列", "二気筒", "4バルブ", "フューエルインジェクション", "湿式クラッチ", "チェーン", "ABS", "セルスタート"],
     },
     {
-        "name": "Ninja ZX-6R", "maker": "KAWASAKI",
+        "name": "Ninja ZX-6R", "maker": "KAWASAKI", "status": "discontinued",
         "displacement": 636, "year": 2019, "max_power": 126, "max_torque": 70, "seat_height": 830,
         "description": "636ccのSS。600ccクラスにプラス36ccで低中速トルクを強化した実戦派モデル。",
         "tags": ["KAWASAKI", "スーパースポーツ", "水冷", "倒立フォーク", "モノショック", "ツインスパーフレーム", "直列", "四気筒", "4バルブ", "フューエルインジェクション", "湿式クラッチ", "チェーン", "ABS", "セルスタート"],
     },
     {
-        "name": "ZX-14R", "maker": "KAWASAKI",
+        "name": "ZX-14R", "maker": "KAWASAKI", "status": "discontinued",
         "displacement": 1441, "year": 2012, "max_power": 200, "max_torque": 163, "seat_height": 800,
         "description": "1441ccのメガスポーツ。圧倒的パワーと快適性でスポーツツーリングの頂点に君臨する。",
         "tags": ["KAWASAKI", "ツアラー", "水冷", "倒立フォーク", "モノショック", "ツインスパーフレーム", "直列", "四気筒", "4バルブ", "フューエルインジェクション", "湿式クラッチ", "チェーン", "ABS", "セルスタート"],
@@ -671,6 +671,8 @@ def seed():
     # バイクデータ投入
     for b in BIKES:
         bike_data = {k: v for k, v in b.items() if k != "tags"}
+        if "status" not in bike_data:
+            bike_data["status"] = "current"
         bike = Motorcycle(**bike_data)
         bike.tags = [tags[t] for t in b["tags"]]
         db.add(bike)

--- a/web/src/components/CatalogPage.tsx
+++ b/web/src/components/CatalogPage.tsx
@@ -43,6 +43,7 @@ export default function CatalogPage() {
     torque: { min: "", max: "" },
     seat_height: { min: "", max: "" },
   });
+  const [statusFilter, setStatusFilter] = useState("");
   const [collapsedCats, setCollapsedCats] = useState<Set<string>>(new Set());
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
@@ -66,8 +67,9 @@ export default function CatalogPage() {
       if (r.min) params.set(field.paramMin, r.min);
       if (r.max) params.set(field.paramMax, r.max);
     }
+    if (statusFilter) params.set("status", statusFilter);
     fetchJson<Motorcycle[]>(`/motorcycles?${params}`).then(setBikes);
-  }, [selectedTags, searchQuery, ranges, singleSelectCats, tags]);
+  }, [selectedTags, searchQuery, ranges, singleSelectCats, tags, statusFilter]);
 
   const toggleTag = (id: number) => {
     const tag = tags.find((t) => t.id === id);
@@ -127,6 +129,7 @@ export default function CatalogPage() {
     setSelectedTags(new Set());
     setSingleSelectCats(new Set());
     setSearchQuery("");
+    setStatusFilter("");
     setRanges({
       displacement: { min: "", max: "" },
       power: { min: "", max: "" },
@@ -138,6 +141,7 @@ export default function CatalogPage() {
   const hasFilters =
     selectedTags.size > 0 ||
     searchQuery !== "" ||
+    statusFilter !== "" ||
     Object.values(ranges).some((r) => r.min || r.max);
 
   const sortedCategories = CATEGORY_ORDER.filter((cat) =>
@@ -165,6 +169,25 @@ export default function CatalogPage() {
           条件クリア
         </button>
       )}
+
+      <div className="filter-section">
+        <h3 className="filter-section-title">モデルステータス</h3>
+        <div className="status-filter-buttons">
+          {[
+            { value: "", label: "すべて" },
+            { value: "current", label: "現行モデル" },
+            { value: "discontinued", label: "生産終了" },
+          ].map((opt) => (
+            <button
+              key={opt.value}
+              className={`status-filter-btn ${statusFilter === opt.value ? "status-filter-active" : ""}`}
+              onClick={() => setStatusFilter(opt.value)}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
 
       <div className="filter-section">
         <h3 className="filter-section-title">スペックで絞り込み</h3>
@@ -298,6 +321,11 @@ export default function CatalogPage() {
                   </div>
                   <div className="card-maker">
                     {bike.maker}{bike.displacement ? ` / ${bike.displacement}cc` : ""}
+                    {bike.status && (
+                      <span className={`status-badge ${bike.status === "current" ? "status-current" : "status-discontinued"}`}>
+                        {bike.status === "current" ? "現行" : "生産終了"}
+                      </span>
+                    )}
                   </div>
                   <div className="card-specs">
                     {bike.max_power != null && (

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -523,6 +523,57 @@ body {
   line-height: var(--lineHeightBase300);
   color: var(--colorNeutralForeground3);
   margin-bottom: var(--spacingM);
+  display: flex;
+  align-items: center;
+  gap: var(--spacingS);
+}
+
+/* Status Badge */
+.status-badge {
+  font-size: var(--fontSizeBase100);
+  padding: var(--spacingXXS) var(--spacingXS);
+  border-radius: var(--borderRadiusSmall);
+  font-weight: var(--fontWeightSemibold);
+  flex-shrink: 0;
+}
+
+.status-current {
+  background: #e6f4ea;
+  color: #1e7e34;
+}
+
+.status-discontinued {
+  background: var(--colorNeutralBackground4);
+  color: var(--colorNeutralForeground4);
+}
+
+/* Status Filter Buttons */
+.status-filter-buttons {
+  display: flex;
+  gap: var(--spacingXS);
+}
+
+.status-filter-btn {
+  flex: 1;
+  padding: var(--spacingXS) var(--spacingS);
+  font-size: var(--fontSizeBase200);
+  font-family: var(--fontFamilyBase);
+  border: var(--strokeWidthThin) solid var(--colorNeutralStroke1);
+  border-radius: var(--borderRadiusMedium);
+  background: var(--colorNeutralBackground1);
+  color: var(--colorNeutralForeground2);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.status-filter-btn:hover {
+  background: var(--colorNeutralBackground3);
+}
+
+.status-filter-active {
+  background: var(--colorBrandBackground);
+  color: #fff;
+  border-color: var(--colorBrandBackground);
 }
 
 .card-specs {

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -15,6 +15,7 @@ export interface Motorcycle {
   seat_height: number | null;
   description: string | null;
   image_url: string | null;
+  status: string | null;
   tags: Tag[];
 }
 


### PR DESCRIPTION
## Summary
- Motorcycleモデルにstatusフィールドを追加（current/discontinued）
- カードにステータスバッジを表示
- ステータスフィルタボタンを追加

## Test plan
- [ ] 生産終了モデルにバッジが表示されること
- [ ] ステータスフィルタで絞り込みできること

🤖 Generated with [Claude Code](https://claude.com/claude-code)