### PR TITLE
feat: メジャーアップデート分離 (#13)

### DIFF
--- a/api/app/models.py
+++ b/api/app/models.py
@@ -30,5 +30,6 @@ class Motorcycle(Base):
     max_torque = Column(Float)              # N·m
     seat_height = Column(Integer)           # mm
     description = Column(Text)
+    model_code = Column(String)               # 型式（例: PC37, RN32）
     image_url = Column(String)
     tags = relationship("Tag", secondary=motorcycle_tag, backref="motorcycles")

--- a/api/app/schemas.py
+++ b/api/app/schemas.py
@@ -18,6 +18,7 @@ class MotorcycleOut(BaseModel):
     max_torque: float | None
     seat_height: int | None
     description: str | None
+    model_code: str | None
     image_url: str | None
     tags: list[TagOut]
     model_config = {"from_attributes": True}

--- a/api/app/seed.py
+++ b/api/app/seed.py
@@ -52,10 +52,16 @@ BIKES = [
         "tags": ["HONDA", "ネイキッド", "水冷", "倒立フォーク", "モノショック", "ダイヤモンドフレーム", "直列", "四気筒", "4バルブ", "フューエルインジェクション", "湿式クラッチ", "チェーン", "ABS", "セルスタート"],
     },
     {
-        "name": "CBR600RR", "maker": "HONDA",
-        "displacement": 599, "year": 2023, "max_power": 121, "max_torque": 63, "seat_height": 820,
-        "description": "ホンダのミドルクラスSS。サーキットでも高い人気を誇る。電子制御満載。",
+        "name": "CBR600RR", "maker": "HONDA", "model_code": "PC40",
+        "displacement": 599, "year": 2013, "max_power": 120, "max_torque": 66, "seat_height": 820,
+        "description": "PC40型CBR600RR。2007年登場の第4世代で、軽量・コンパクト化を追求したミドルSS。",
         "tags": ["HONDA", "スーパースポーツ", "水冷", "倒立フォーク", "モノショック", "ツインスパーフレーム", "直列", "四気筒", "4バルブ", "フューエルインジェクション", "湿式クラッチ", "チェーン", "ABS", "セルスタート"],
+    },
+    {
+        "name": "CBR600RR", "maker": "HONDA", "model_code": "PC37",
+        "displacement": 599, "year": 2005, "max_power": 118, "max_torque": 66, "seat_height": 820,
+        "description": "PC37型CBR600RR。2003年登場の第3世代。ユニットプロリンクサスペンション初採用モデル。",
+        "tags": ["HONDA", "スーパースポーツ", "水冷", "倒立フォーク", "モノショック", "ツインスパーフレーム", "直列", "四気筒", "4バルブ", "フューエルインジェクション", "湿式クラッチ", "チェーン", "ABS無し", "セルスタート"],
     },
     {
         "name": "CRF250L", "maker": "HONDA",
@@ -175,10 +181,22 @@ BIKES = [
         "tags": ["YAMAHA", "ネオクラシック", "空冷", "テレスコピックフォーク", "ツインショック", "ダイヤモンドフレーム", "直列", "単気筒", "2バルブ", "フューエルインジェクション", "湿式クラッチ", "チェーン", "ABS無し", "キックスタート"],
     },
     {
-        "name": "YZF-R1", "maker": "YAMAHA",
+        "name": "YZF-R1", "maker": "YAMAHA", "model_code": "RN65",
         "displacement": 997, "year": 2019, "max_power": 200, "max_torque": 113, "seat_height": 855,
-        "description": "クロスプレーンエンジン搭載のフラッグシップSS。MotoGP M1の技術を受け継ぐ。",
+        "description": "RN65型YZF-R1。2015年登場のクロスプレーンエンジン搭載第6世代。MotoGP M1直系技術。",
         "tags": ["YAMAHA", "スーパースポーツ", "水冷", "倒立フォーク", "モノショック", "ツインスパーフレーム", "直列", "四気筒", "4バルブ", "フューエルインジェクション", "湿式クラッチ", "チェーン", "コーナリングABS", "セルスタート"],
+    },
+    {
+        "name": "YZF-R1", "maker": "YAMAHA", "model_code": "RN32",
+        "displacement": 997, "year": 2009, "max_power": 182, "max_torque": 115, "seat_height": 835,
+        "description": "RN32型YZF-R1。2009年登場の第5世代。クロスプレーンクランクシャフト初採用モデル。",
+        "tags": ["YAMAHA", "スーパースポーツ", "水冷", "倒立フォーク", "モノショック", "ツインスパーフレーム", "直列", "四気筒", "4バルブ", "フューエルインジェクション", "湿式クラッチ", "チェーン", "ABS無し", "セルスタート"],
+    },
+    {
+        "name": "YZF-R1", "maker": "YAMAHA", "model_code": "4XV",
+        "displacement": 998, "year": 1998, "max_power": 150, "max_torque": 108, "seat_height": 815,
+        "description": "初代YZF-R1。1998年登場で998ccリッターSSの概念を変えた革命的モデル。",
+        "tags": ["YAMAHA", "スーパースポーツ", "水冷", "倒立フォーク", "モノショック", "ツインスパーフレーム", "直列", "四気筒", "5バルブ", "キャブレター", "湿式クラッチ", "チェーン", "ABS無し", "セルスタート"],
     },
     {
         "name": "YZF-R7", "maker": "YAMAHA",

--- a/web/src/components/CatalogPage.tsx
+++ b/web/src/components/CatalogPage.tsx
@@ -298,6 +298,7 @@ export default function CatalogPage() {
                   </div>
                   <div className="card-maker">
                     {bike.maker}{bike.displacement ? ` / ${bike.displacement}cc` : ""}
+                    {bike.model_code && <span className="card-model-code">({bike.model_code})</span>}
                   </div>
                   <div className="card-specs">
                     {bike.max_power != null && (

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -525,6 +525,12 @@ body {
   margin-bottom: var(--spacingM);
 }
 
+.card-model-code {
+  font-size: var(--fontSizeBase200);
+  color: var(--colorNeutralForeground4);
+  margin-left: var(--spacingXS);
+}
+
 .card-specs {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -14,6 +14,7 @@ export interface Motorcycle {
   max_torque: number | null;
   seat_height: number | null;
   description: string | null;
+  model_code: string | null;
   image_url: string | null;
   tags: Tag[];
 }


### PR DESCRIPTION
## Summary
- Motorcycleモデルにmodel_codeフィールドを追加
- CBR600RR, YZF-R1に世代別バリアントを追加
- 同一モデルの世代違いを区別可能に

## Test plan
- [ ] model_code付きの車種が表示されること
- [ ] 世代別バリアントが個別に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)