### PR TITLE
feat: 身長別足つき目安表示 (#21)

### DIFF
--- a/web/src/components/CatalogPage.tsx
+++ b/web/src/components/CatalogPage.tsx
@@ -24,6 +24,16 @@ const CATEGORY_ORDER = [
   "clutch", "drive", "abs", "start",
 ];
 
+function getFootReach(heightCm: number, seatHeightMm: number): string {
+  // 股下は身長の約45%、足つき時の脚の伸び分を考慮
+  const inseam = heightCm * 0.45 * 10; // mm
+  const diff = inseam - seatHeightMm;
+  if (diff >= 50) return "両足べったり";
+  if (diff >= 0) return "両足つま先";
+  if (diff >= -30) return "片足つま先";
+  return "厳しい";
+}
+
 const RANGE_FIELDS = [
   { key: "displacement", label: "排気量 (cc)", paramMin: "displacement_min", paramMax: "displacement_max" },
   { key: "power", label: "最高出力 (PS)", paramMin: "power_min", paramMax: "power_max" },
@@ -43,6 +53,7 @@ export default function CatalogPage() {
     torque: { min: "", max: "" },
     seat_height: { min: "", max: "" },
   });
+  const [userHeight, setUserHeight] = useState("");
   const [collapsedCats, setCollapsedCats] = useState<Set<string>>(new Set());
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
@@ -165,6 +176,20 @@ export default function CatalogPage() {
           条件クリア
         </button>
       )}
+
+      <div className="filter-section">
+        <h3 className="filter-section-title">あなたの体格</h3>
+        <div className="range-field">
+          <label className="range-label">身長 (cm)</label>
+          <input
+            type="number"
+            placeholder="例: 170"
+            value={userHeight}
+            onChange={(e) => setUserHeight(e.target.value)}
+            className="range-input"
+          />
+        </div>
+      </div>
 
       <div className="filter-section">
         <h3 className="filter-section-title">スペックで絞り込み</h3>
@@ -322,6 +347,12 @@ export default function CatalogPage() {
                       <div className="spec-item">
                         <span className="spec-label">排気量</span>
                         <span className="spec-value">{bike.displacement} cc</span>
+                      </div>
+                    )}
+                    {userHeight && bike.seat_height != null && (
+                      <div className="spec-item">
+                        <span className="spec-label">足つき目安</span>
+                        <span className="spec-value spec-foot-reach">{getFootReach(Number(userHeight), bike.seat_height)}</span>
                       </div>
                     )}
                   </div>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -555,6 +555,14 @@ body {
   color: var(--colorNeutralForeground1);
 }
 
+.spec-foot-reach {
+  font-weight: var(--fontWeightBold);
+  padding: var(--spacingXXS) var(--spacingXS);
+  border-radius: var(--borderRadiusSmall);
+  background: #e8f4fd;
+  color: var(--colorBrandForeground1);
+}
+
 .card-description {
   font-size: var(--fontSizeBase300);
   line-height: var(--lineHeightBase300);


### PR DESCRIPTION
## Summary
- ユーザーの身長入力に基づく足つき目安を表示
- シート高との比較で4段階判定（両足べったり/両足つま先/片足つま先/厳しい）

## Test plan
- [ ] 身長入力後、各カードに足つき目安が表示されること
- [ ] シート高に応じて適切な判定がされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)