### PR TITLE
feat: カード画像表示の改善 (#24)

### DIFF
--- a/web/src/components/CatalogPage.tsx
+++ b/web/src/components/CatalogPage.tsx
@@ -286,11 +286,28 @@ export default function CatalogPage() {
           <div className="card-grid">
             {bikes.map((bike) => (
               <div key={bike.id} className="bike-card">
-                {bike.image_url && (
-                  <div className="card-image">
-                    <img src={bike.image_url} alt={bike.name} />
-                  </div>
-                )}
+                <div className="card-image">
+                  {bike.image_url ? (
+                    <img
+                      src={bike.image_url}
+                      alt={bike.name}
+                      loading="lazy"
+                      onError={(e) => {
+                        (e.target as HTMLImageElement).style.display = "none";
+                        (e.target as HTMLImageElement).parentElement!.classList.add("card-image-placeholder");
+                      }}
+                    />
+                  ) : (
+                    <div className="card-image-placeholder">
+                      <svg width="48" height="48" viewBox="0 0 48 48" fill="none">
+                        <path d="M8 38L18 28L24 34L32 26L40 34" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+                        <rect x="6" y="8" width="36" height="32" rx="3" stroke="currentColor" strokeWidth="2" />
+                        <circle cx="18" cy="18" r="3" stroke="currentColor" strokeWidth="2" />
+                      </svg>
+                      <span className="placeholder-label">{bike.maker}</span>
+                    </div>
+                  )}
+                </div>
                 <div className="card-body">
                   <div className="card-header-row">
                     <h3 className="card-title">{bike.name}</h3>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -480,7 +480,7 @@ body {
 
 .card-image {
   width: 100%;
-  height: 180px;
+  aspect-ratio: 16 / 9;
   overflow: hidden;
   background: var(--colorNeutralBackground4);
 }
@@ -489,6 +489,25 @@ body {
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+
+.card-image-placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacingS);
+  color: var(--colorNeutralForeground4);
+  background: var(--colorNeutralBackground4);
+}
+
+.placeholder-label {
+  font-size: var(--fontSizeBase200);
+  line-height: var(--lineHeightBase200);
+  font-weight: var(--fontWeightSemibold);
+  color: var(--colorNeutralForeground3);
 }
 
 .card-body {


### PR DESCRIPTION
## Summary
- 画像がない車種にプレースホルダー（アイコン+メーカー名）を表示
- 画像読み込みエラー時のフォールバック処理を追加
- lazy loadingでパフォーマンス向上
- アスペクト比16:9に統一

## Test plan
- [ ] 画像のない車種にプレースホルダーが表示されること
- [ ] カードの高さが統一されていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)