### PR TITLE
feat: カード画像を削除し、ヘッダーレイアウトを改善

### DIFF
--- a/web/src/components/CatalogPage.tsx
+++ b/web/src/components/CatalogPage.tsx
@@ -549,42 +549,24 @@ export default function CatalogPage() {
           <div className="card-grid">
             {displayBikes.map((bike) => (
               <div key={bike.id} className="bike-card">
-                <div className="card-image">
-                  {bike.image_url ? (
-                    <img
-                      src={bike.image_url}
-                      alt={bike.name}
-                      loading="lazy"
-                      onError={(e) => {
-                        (e.target as HTMLImageElement).style.display = "none";
-                        (e.target as HTMLImageElement).parentElement!.classList.add("card-image-placeholder");
-                      }}
-                    />
-                  ) : (
-                    <div className="card-image-placeholder">
-                      <svg width="48" height="48" viewBox="0 0 48 48" fill="none">
-                        <path d="M8 38L18 28L24 34L32 26L40 34" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
-                        <rect x="6" y="8" width="36" height="32" rx="3" stroke="currentColor" strokeWidth="2" />
-                        <circle cx="18" cy="18" r="3" stroke="currentColor" strokeWidth="2" />
-                      </svg>
-                      <span className="placeholder-label">{bike.maker}</span>
-                    </div>
-                  )}
-                  <button
-                    className={`favorite-btn ${favorites.has(bike.id) ? "favorite-active" : ""}`}
-                    onClick={(e) => { e.stopPropagation(); toggleFavorite(bike.id); }}
-                    aria-label="お気に入り"
-                  >
-                    {favorites.has(bike.id) ? "♥" : "♡"}
-                  </button>
-                  {bike.status === "discontinued" && (
-                    <span className="status-badge status-discontinued">生産終了</span>
-                  )}
-                </div>
                 <div className="card-body">
                   <div className="card-header-row">
-                    <h3 className="card-title">{bike.name}</h3>
-                    {bike.year && <span className="card-year">{bike.year}年</span>}
+                    <div className="card-header-left">
+                      <h3 className="card-title">{bike.name}</h3>
+                      {bike.status === "discontinued" && (
+                        <span className="status-badge status-discontinued">生産終了</span>
+                      )}
+                    </div>
+                    <div className="card-header-right">
+                      {bike.year && <span className="card-year">{bike.year}年</span>}
+                      <button
+                        className={`favorite-btn ${favorites.has(bike.id) ? "favorite-active" : ""}`}
+                        onClick={(e) => { e.stopPropagation(); toggleFavorite(bike.id); }}
+                        aria-label="お気に入り"
+                      >
+                        {favorites.has(bike.id) ? "♥" : "♡"}
+                      </button>
+                    </div>
                   </div>
                   <div className="card-maker">
                     {bike.maker}{bike.displacement ? ` / ${bike.displacement}cc` : ""}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -506,38 +506,6 @@ body {
   transform: translateY(-2px);
 }
 
-.card-image {
-  position: relative;
-  width: 100%;
-  aspect-ratio: 16 / 9;
-  overflow: hidden;
-  background: var(--colorNeutralBackground4);
-}
-
-.card-image img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.card-image-placeholder {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: var(--spacingS);
-  color: var(--colorNeutralForeground4);
-  background: var(--colorNeutralBackground4);
-}
-
-.placeholder-label {
-  font-size: var(--fontSizeBase200);
-  line-height: var(--lineHeightBase200);
-  font-weight: var(--fontWeightSemibold);
-  color: var(--colorNeutralForeground3);
-}
 
 .card-body {
   padding: var(--spacingL) var(--spacingXL) var(--spacingXL);
@@ -546,8 +514,24 @@ body {
 .card-header-row {
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
+  align-items: flex-start;
+  gap: var(--spacingS);
   margin-bottom: var(--spacingXS);
+}
+
+.card-header-left {
+  display: flex;
+  align-items: center;
+  gap: var(--spacingS);
+  min-width: 0;
+  flex: 1;
+}
+
+.card-header-right {
+  display: flex;
+  align-items: center;
+  gap: var(--spacingXS);
+  flex-shrink: 0;
 }
 
 .card-title {
@@ -846,26 +830,18 @@ body {
 
 /* Favorite Button */
 .favorite-btn {
-  position: absolute;
-  top: var(--spacingS);
-  right: var(--spacingS);
-  background: rgba(255, 255, 255, 0.85);
+  background: none;
   border: none;
-  border-radius: var(--borderRadiusCircular);
-  width: 32px;
-  height: 32px;
   font-size: 18px;
   line-height: 1;
   cursor: pointer;
   color: var(--colorNeutralForeground4);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: all 0.15s;
+  padding: var(--spacingXXS);
+  transition: color 0.15s;
+  flex-shrink: 0;
 }
 
 .favorite-btn:hover {
-  background: rgba(255, 255, 255, 1);
   color: #e74c3c;
 }
 
@@ -875,14 +851,12 @@ body {
 
 /* Status Badge */
 .status-badge {
-  position: absolute;
-  top: var(--spacingS);
-  left: var(--spacingS);
   padding: var(--spacingXXS) var(--spacingS);
   border-radius: var(--borderRadiusSmall);
   font-size: var(--fontSizeBase100);
   font-weight: var(--fontWeightSemibold);
   line-height: var(--lineHeightBase100);
+  flex-shrink: 0;
 }
 
 .status-discontinued {


### PR DESCRIPTION
## Summary
- カードから画像セクション（image_url表示、プレースホルダー）を削除
- お気に入りボタンとステータスバッジをカードヘッダー行に移動
- ヘッダーを左右に分割し、レイアウトを整理

## Test plan
- [ ] カード一覧が画像なしで正しく表示されること
- [ ] お気に入りボタンが正常に動作すること
- [ ] 生産終了バッジが正しく表示されること
- [ ] レスポンシブ表示が崩れないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)